### PR TITLE
add abstract base controller, update entity and fixtures

### DIFF
--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Controller;
+
+use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Validator\Validator\ValidatorInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+
+abstract class BaseController extends AbstractController
+{
+    public function __construct(
+        private readonly ValidatorInterface $validator,
+        protected readonly SerializerInterface $serializer,
+    ) {
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    protected function validate(object $formData): array
+    {
+        /** @var array<string, string[]> $messages */
+        $messages = [];
+        $errors = $this->validator->validate($formData);
+
+        if ($errors->count() > 0) {
+            foreach ($errors as $violation) {
+                $messages[(string) $violation->getPropertyPath()][] = (string) $violation->getMessage();
+            }
+        }
+
+        return $messages;
+    }
+}

--- a/src/DataFixtures/AppFixtures.php
+++ b/src/DataFixtures/AppFixtures.php
@@ -6,22 +6,20 @@ use App\Entity\Message;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
 use Faker\Factory;
-use Symfony\Component\Uid\Uuid;
-use function Psl\Iter\random;
 
 class AppFixtures extends Fixture
 {
     public function load(ObjectManager $manager): void
     {
         $faker = Factory::create();
-        
-        foreach (range(1, 10) as $i) {
-            $message = new Message();
-            $message->setUuid(Uuid::v6()->toRfc4122());
-            $message->setText($faker->sentence);
-            $message->setStatus(random(['sent', 'read']));
-            $message->setCreatedAt(new \DateTime());
-            
+
+        for ($i = 0; $i < 5; $i++) {
+            $message = Message::compose($faker->sentence(), Message::STATUS_SENT);
+            $manager->persist($message);
+        }
+
+        for ($i = 0; $i < 5; $i++) {
+            $message = Message::compose($faker->sentence(), Message::STATUS_READ);
             $manager->persist($message);
         }
 

--- a/src/Entity/Message.php
+++ b/src/Entity/Message.php
@@ -6,27 +6,34 @@ use App\Repository\MessageRepository;
 use DateTime;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Uid\Uuid;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 #[ORM\Entity(repositoryClass: MessageRepository::class)]
-/**
- * TODO: Review Message class
- */
+
 class Message
 {
+    public const STATUS_SENT = 'sent';
+    public const STATUS_READ = 'read';
+    public const RESPONSE_MESSAGE_SENT = 'The message has been sent!';
+
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column]
     private ?int $id = null;
 
     #[ORM\Column(type: Types::GUID)]
+    #[Groups(['message:summary'])]
     private ?string $uuid = null;
 
     #[ORM\Column(length: 255)]
+    #[Groups(['message:summary'])]
     private ?string $text = null;
 
     #[ORM\Column(length: 255, nullable: true)]
+    #[Groups(['message:summary'])]
     private ?string $status = null;
-    
+
     #[ORM\Column(type: 'datetime')]
     private DateTime $createdAt;
 
@@ -79,7 +86,18 @@ class Message
     public function setCreatedAt(DateTime $createdAt): static
     {
         $this->createdAt = $createdAt;
-        
+
         return $this;
+    }
+
+    public static function compose(string $text, string $status = self::STATUS_SENT): self
+    {
+        $message = new self();
+        $message->setUuid(Uuid::v6()->toRfc4122());
+        $message->setText($text);
+        $message->setStatus($status);
+        $message->setCreatedAt(new \DateTime());
+
+        return $message;
     }
 }


### PR DESCRIPTION
I have created a new method Message::compose in the Message entity and added a corresponding constant (e.g., STATUS_SENT, STATUS_READ) to represent message statuses. In the AppFixtures class, you used this new compose method to create and persist 10 sample messages (5 with STATUS_SENT and 5 with STATUS_READ) using Faker-generated content. You also updated the BaseController to include validation logic using Symfony’s Validator component.